### PR TITLE
Feat/course api

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,136 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:toc-title: 목차
+:sectlinks:
+= 어디갈까? REST API 문서
+
+== 회원 API
+
+=== 회원 가입 요청
+
+// include::{snippets}/index/http-request.adoc[]
+
+=== 로그인 요청
+
+// include::{snippets}/index/http-request.adoc[]
+
+=== 내 정보 수정
+
+// include::{snippets}/index/http-request.adoc[]
+
+=== ㅤ
+
+== 코스 API
+
+// === 인기 코스 목록 응답
+//
+// include::{snippets}/index/http-response.adoc[]
+//
+// === 최근 올라온 코스 목록 응답
+//
+// include::{snippets}/index/http-response.adoc[]
+
+=== 새 코스 만들기
+
+==== Http Request
+include::{snippets}/course/create/http-request.adoc[]
+include::{snippets}/course/create/request-fields.adoc[]
+
+==== Http Response
+include::{snippets}/course/create/http-response.adoc[]
+include::{snippets}/course/create/response-fields.adoc[]
+
+=== 코스 단건 조회
+
+==== Http Request
+include::{snippets}/course/get-single/path-parameters.adoc[]
+include::{snippets}/course/get-single/http-request.adoc[]
+
+==== Http Response
+include::{snippets}/course/get-single/http-response.adoc[]
+include::{snippets}/course/get-single/response-fields.adoc[]
+
+=== 코스 목록 조회
+
+==== Http Request
+include::{snippets}/course/get-list/http-request.adoc[]
+
+==== Http Response
+include::{snippets}/course/get-list/http-response.adoc[]
+include::{snippets}/course/get-list/response-fields.adoc[]
+
+=== 코스 편집 요청
+
+==== Http Request
+include::{snippets}/course/update/path-parameters.adoc[]
+include::{snippets}/course/update/http-request.adoc[]
+include::{snippets}/course/update/request-fields.adoc[]
+
+==== Http Response
+include::{snippets}/course/update/http-response.adoc[]
+include::{snippets}/course/update/response-fields.adoc[]
+
+=== 코스 삭제 요청
+
+==== Http Request
+include::{snippets}/course/delete/path-parameters.adoc[]
+include::{snippets}/course/delete/http-request.adoc[]
+
+==== Http Response
+include::{snippets}/course/delete/http-response.adoc[]
+include::{snippets}/course/delete/response-fields.adoc[]
+
+=== 내 코스 응답
+
+==== Http Request
+include::{snippets}/user/course/get/path-parameters.adoc[]
+include::{snippets}/user/course/get/http-request.adoc[]
+
+==== Http Response
+include::{snippets}/user/course/get/http-response.adoc[]
+include::{snippets}/user/course/get/response-fields.adoc[]
+
+=== 코스 리뷰 응답
+
+// include::{snippets}/index/http-response.adoc[]
+
+=== ㅤ
+
+== 장소 API
+
+=== 장소 정보 응답
+
+지도 api 사용 예정
+
+=== 장소 리뷰 응답
+
+// include::{snippets}/index/http-response.adoc[]
+
+=== 즐겨찾기(폴더) 응답
+
+// include::{snippets}/index/http-response.adoc[]
+
+=== 장소 내 코스에 추가 요청
+
+// include::{snippets}/index/http-request.adoc[]
+
+=== 장소 내 즐겨찾기(폴더)에 추가 요청
+
+// include::{snippets}/index/http-request.adoc[]
+
+=== ㅤ
+
+=== 내 즐겨찾기(폴더) 응답
+
+// include::{snippets}/index/http-response.adoc[]
+
+=== 내 즐겨찾기(폴더) 삭제 요청
+
+// include::{snippets}/index/http-request.adoc[]
+
+=== 내 즐겨찾기(폴더) 안에 장소 응답
+
+// include::{snippets}/index/http-response.adoc[]

--- a/src/main/java/com/backend/api/controller/course/CourseController.java
+++ b/src/main/java/com/backend/api/controller/course/CourseController.java
@@ -1,0 +1,68 @@
+package com.backend.api.controller.course;
+
+import com.backend.api.controller.ApiResponse;
+import com.backend.api.request.course.CreateCourse;
+import com.backend.api.request.course.UpdateCourse;
+import com.backend.api.response.course.CourseResponse;
+import com.backend.api.response.user.LoginResponse;
+import com.backend.api.service.course.CourseService;
+import com.backend.api.util.Login;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @GetMapping("/restDocsTest")
+    public String restDocsTestAPI() {
+        return "test";
+    }
+
+    //코스 생성
+    @PostMapping("/courses")
+    public ApiResponse<CourseResponse> createCourse(@Login LoginResponse loginResponse, @RequestBody @Valid CreateCourse request) {
+        return ApiResponse.ok(courseService.createCourse(request, loginResponse));
+    }
+
+    //코스 목록 조회(ex 홈페이지에 여러개)
+    @GetMapping("/courses")
+    public ApiResponse<List<CourseResponse>> getCourses() {
+        return ApiResponse.ok(courseService.getList());
+    }
+
+    //코스 단건 조회(코스 id 값으로)
+    @GetMapping("/courses/{id}")
+    public ApiResponse<CourseResponse> getCourse(@PathVariable Long id) {
+        return ApiResponse.ok(courseService.getCourse(id));
+    }
+
+    //코스 단건 수정(코스 id 값으로)
+    @PatchMapping("/courses/{id}")
+    public ApiResponse<CourseResponse> updateCourse(@Login LoginResponse loginResponse, @PathVariable Long id, @RequestBody @Valid UpdateCourse request) {
+        return ApiResponse.ok(courseService.updateCourse(loginResponse, id, request));
+    }
+
+    //코스 단건 삭제(코스 id 값으로)
+    @DeleteMapping("/courses/{id}")
+    public ApiResponse<CourseResponse> deleteCourse(@PathVariable Long id) {
+        courseService.deleteCourse(id);
+        return ApiResponse.<CourseResponse>builder()
+                .status(HttpStatus.OK)
+                .message("코스 제거 성공")
+                .build();
+    }
+
+    //코스 목록 조회(사용자 id 값으로)
+    @GetMapping("/users/courses/{userId}")
+    public ApiResponse<List<CourseResponse>> getUserCourses(@PathVariable Long userId) {
+        return ApiResponse.ok(courseService.getCoursesByUserId(userId));
+    }
+}

--- a/src/main/java/com/backend/api/entity/course/Course.java
+++ b/src/main/java/com/backend/api/entity/course/Course.java
@@ -1,19 +1,38 @@
 package com.backend.api.entity.course;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.backend.api.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Course {
 
-    @Id @GeneratedValue(strategy = IDENTITY)
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = LAZY, cascade = ALL)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Column(nullable = false)
     private String name;
 
+    @Builder
+    public Course(String name, User user) {
+        this.name = name;
+        this.user = user;
+    }
+
+    public void update(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/backend/api/repository/course/CourseRepository.java
+++ b/src/main/java/com/backend/api/repository/course/CourseRepository.java
@@ -1,0 +1,13 @@
+package com.backend.api.repository.course;
+
+import com.backend.api.entity.course.Course;
+import com.backend.api.response.course.CourseResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
+    List<CourseResponse> findByUserId(Long userId);
+}

--- a/src/main/java/com/backend/api/request/course/CreateCourse.java
+++ b/src/main/java/com/backend/api/request/course/CreateCourse.java
@@ -1,0 +1,21 @@
+package com.backend.api.request.course;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateCourse {
+
+    @NotBlank(message = "코스명을 입력해주세요")
+    private String name;
+
+    @Builder
+    public CreateCourse(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/backend/api/request/course/UpdateCourse.java
+++ b/src/main/java/com/backend/api/request/course/UpdateCourse.java
@@ -1,0 +1,21 @@
+package com.backend.api.request.course;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateCourse {
+
+    @NotBlank(message = "코스명을 입력해주세요")
+    private String name;
+
+    @Builder
+    public UpdateCourse(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/backend/api/response/course/CourseResponse.java
+++ b/src/main/java/com/backend/api/response/course/CourseResponse.java
@@ -1,0 +1,26 @@
+package com.backend.api.response.course;
+
+import com.backend.api.entity.course.Course;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CourseResponse {
+
+    private final String name;
+
+    @Builder
+    public CourseResponse(String name) {
+        this.name = name;
+    }
+
+    public CourseResponse(Course course) {
+        this.name = course.getName();
+    }
+
+    public static CourseResponse of(Course course) {
+        return CourseResponse.builder()
+                .name(course.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/api/service/course/CourseService.java
+++ b/src/main/java/com/backend/api/service/course/CourseService.java
@@ -1,0 +1,80 @@
+package com.backend.api.service.course;
+
+import com.backend.api.entity.course.Course;
+import com.backend.api.entity.user.User;
+import com.backend.api.exception.UserNotFoundException;
+import com.backend.api.repository.course.CourseRepository;
+import com.backend.api.repository.user.UserRepository;
+import com.backend.api.request.course.CreateCourse;
+import com.backend.api.request.course.UpdateCourse;
+import com.backend.api.response.course.CourseResponse;
+import com.backend.api.response.user.LoginResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseService {
+
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+
+    @Transactional
+    public CourseResponse createCourse(CreateCourse createCourse, LoginResponse loginResponse) {
+        User user = userRepository.findByEmail(loginResponse.getEmail())
+                .orElseThrow(UserNotFoundException::new);
+
+        Course course = Course.builder()
+                .name(createCourse.getName())
+                .user(user)
+                .build();
+
+        return CourseResponse.of(courseRepository.save(course));
+    }
+
+    @Transactional
+    public CourseResponse updateCourse(LoginResponse loginResponse, Long id, UpdateCourse updateCourse) {
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("해당 코스가 없습니다. id=" + id));
+
+        course.update(updateCourse.getName());
+
+        userRepository.findByEmail(loginResponse.getEmail())
+                .orElseThrow(() -> new NoSuchElementException("해당 유저가 없습니다. email=" + loginResponse.getEmail()));
+
+        return CourseResponse.of(course);
+    }
+
+    @Transactional
+    public void deleteCourse(Long id) {
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("해당 코스가 없습니다. id=" + id));
+
+        courseRepository.deleteById(id);
+    }
+
+    public CourseResponse getCourse(Long id) {
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("해당 코스가 없습니다. id=" + id));
+
+        return CourseResponse.builder()
+                .name(course.getName())
+                .build();
+    }
+
+    public List<CourseResponse> getList() {
+        return courseRepository.findAll().stream()
+                .map(CourseResponse::new)
+                .toList();
+    }
+
+    public List<CourseResponse> getCoursesByUserId(Long userId) {
+        return courseRepository.findByUserId(userId);
+    }
+}

--- a/src/test/java/com/backend/api/ServiceTestSupport.java
+++ b/src/test/java/com/backend/api/ServiceTestSupport.java
@@ -1,8 +1,10 @@
 package com.backend.api;
 
 import com.backend.api.jwt.TokenProvider;
+import com.backend.api.repository.course.CourseRepository;
 import com.backend.api.repository.user.UserRepository;
 import com.backend.api.service.auth.AuthService;
+import com.backend.api.service.course.CourseService;
 import com.backend.api.service.user.UserService;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,4 +30,9 @@ public abstract class ServiceTestSupport {
     @Autowired
     protected PasswordEncoder passwordEncoder;
 
+    @Autowired
+    protected CourseService courseService;
+
+    @Autowired
+    protected CourseRepository courseRepository;
 }

--- a/src/test/java/com/backend/api/controller/course/CourseControllerTest.java
+++ b/src/test/java/com/backend/api/controller/course/CourseControllerTest.java
@@ -1,0 +1,19 @@
+package com.backend.api.controller.course;
+
+import com.backend.api.repository.course.CourseRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+}

--- a/src/test/java/com/backend/api/docs/course/CourseControllerDocTest.java
+++ b/src/test/java/com/backend/api/docs/course/CourseControllerDocTest.java
@@ -1,0 +1,272 @@
+package com.backend.api.docs.course;
+
+import com.backend.api.controller.course.CourseController;
+import com.backend.api.docs.RestDocsSupport;
+import com.backend.api.request.course.CreateCourse;
+import com.backend.api.request.course.UpdateCourse;
+import com.backend.api.response.course.CourseResponse;
+import com.backend.api.response.user.LoginResponse;
+import com.backend.api.service.course.CourseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ExtendWith(RestDocumentationExtension.class) //junit5 사용시 문서 생성
+class CourseControllerDocTest extends RestDocsSupport {
+
+    private final CourseService courseService = mock(CourseService.class);
+
+    @Override
+    protected Object initController() {
+        return new CourseController(courseService);
+    }
+
+
+    @Test
+    @DisplayName("테스트")
+    void test1() throws Exception {
+        //expected
+        mockMvc.perform(get("/api/restDocsTest")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("index"));
+    }
+
+    @Test
+    @DisplayName("코스 생성")
+    void createCourse() throws Exception {
+        CreateCourse course = CreateCourse.builder()
+                .name("코스 1")
+                .build();
+
+        given(courseService.createCourse(any(CreateCourse.class), any(LoginResponse.class)))
+                .willReturn(CourseResponse.builder()
+                        .name("코스 1")
+                        .build());
+
+        //expected
+        mockMvc.perform(post("/api/courses")
+                        .content(objectMapper.writeValueAsString(course))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("/course/create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                        .description("코스 이름")),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                        .description("코스 1"))
+                ));
+    }
+
+    @Test
+    @DisplayName("코스 단건 조회")
+    void getCourse() throws Exception {
+        given(courseService.getCourse(any(Long.class)))
+                .willReturn(CourseResponse.builder()
+                        .name("코스 1")
+                        .build());
+
+        //expected
+        mockMvc.perform(get("/api/courses/{id}", 1L)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("/course/get-single",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("코스 ID")),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                        .description("코스 1"))));
+
+    }
+
+    @Test
+    @DisplayName("코스 목록 조회")
+    void getCourseList() throws Exception {
+        given(courseService.getList())
+                .willReturn(List.of(
+                        CourseResponse.builder()
+                                .name("코스 1")
+                                .build(),
+                        CourseResponse.builder()
+                                .name("코스 2")
+                                .build(),
+                        CourseResponse.builder()
+                                .name("코스 3")
+                                .build()
+                ));
+
+        //expected
+        mockMvc.perform(get("/api/courses")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("/course/get-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.ARRAY)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data[].name").type(JsonFieldType.STRING)
+                                        .description("코스 목록"))));
+    }
+
+    @Test
+    @DisplayName("내 코스 조회")
+    void getUserCourse() throws Exception {
+        given(courseService.getCoursesByUserId(any(Long.class)))
+                .willReturn(List.of(
+                        CourseResponse.builder()
+                                .name("내 코스 1")
+                                .build(),
+                        CourseResponse.builder()
+                                .name("내 코스 2")
+                                .build(),
+                        CourseResponse.builder()
+                                .name("내 코스 3")
+                                .build()
+                ));
+
+        //expected
+        mockMvc.perform(get("/api/users/courses/{userId}", 1L)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("/user/course/get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("userId").description("사용자 ID")),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.ARRAY)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data[].name").type(JsonFieldType.STRING)
+                                        .description("코스 목록"))));
+
+    }
+
+    @Test
+    @DisplayName("코스 편집")
+    void updateUserCourse() throws Exception {
+        given(courseService.updateCourse(any(LoginResponse.class), any(Long.class), any(UpdateCourse.class)))
+                .willReturn(CourseResponse.builder()
+                        .name("편집된 코스")
+                        .build());
+
+        UpdateCourse updateCourse = UpdateCourse.builder()
+                .name("코스 1")
+                .build();
+
+        //expected
+        mockMvc.perform(patch("/api/courses/{id}", 1L)
+                        .content(objectMapper.writeValueAsString(updateCourse))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("/course/update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("코스 ID")),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                        .description("코스 이름")),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING)
+                                        .description("수정된 코스"))));
+    }
+
+    @Test
+    @DisplayName("코스 삭제")
+    void deleteUserCourse() throws Exception {
+
+        //expected
+        mockMvc.perform(delete("/api/courses/{id}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("/course/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("코스 ID")),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.NULL)
+                                        .description("응답 데이터"))));
+        verify(courseService, times(1)).deleteCourse(any(Long.class));
+    }
+}

--- a/src/test/java/com/backend/api/service/course/CourseServiceTest.java
+++ b/src/test/java/com/backend/api/service/course/CourseServiceTest.java
@@ -1,0 +1,156 @@
+package com.backend.api.service.course;
+
+import com.backend.api.ServiceTestSupport;
+import com.backend.api.entity.course.Course;
+import com.backend.api.entity.user.Gender;
+import com.backend.api.entity.user.User;
+import com.backend.api.entity.util.Address;
+import com.backend.api.request.course.CreateCourse;
+import com.backend.api.request.course.UpdateCourse;
+import com.backend.api.response.course.CourseResponse;
+import com.backend.api.response.user.LoginResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class CourseServiceTest extends ServiceTestSupport {
+
+    @BeforeEach
+    void setUp() {
+        courseRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private User userCreate() {
+        return User.builder()
+                .email("user@gmail.com")
+                .password(passwordEncoder.encode("1111"))
+                .nickName("user")
+                .address(Address.builder()
+                        .city("서울시")
+                        .street("도봉로 106길 23")
+                        .zipcode("102동 208호")
+                        .build())
+                .birth("20000418")
+                .gender(Gender.MAN)
+                .build();
+    }
+
+    private LoginResponse loginCreate(User user) {
+        return LoginResponse.builder()
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
+    }
+
+    @Test
+    @DisplayName("코스 생성")
+    void createCourse() {
+        //given
+        CreateCourse course = CreateCourse.builder()
+                .name("코스 1")
+                .build();
+
+        User user = userCreate();
+        userRepository.save(user);
+        LoginResponse loginResponse = loginCreate(user);
+
+        //when
+        courseService.createCourse(course, loginResponse);
+
+        //then
+        assertEquals(1, courseRepository.count());
+        assertEquals("코스 1", courseRepository.findAll().get(0).getName());
+
+    }
+
+    @Test
+    @DisplayName("코스 단건 조회")
+    void getCourse() throws Exception {
+        //given
+        Course course = Course.builder()
+                .name("코스 1")
+                .build();
+        courseRepository.save(course);
+
+        //when
+        CourseResponse courseResponse = courseService.getCourse(course.getId());
+
+        //then
+        assertEquals(1, courseRepository.count());
+        assertEquals("코스 1", courseResponse.getName());
+
+    }
+
+    @Test
+    @DisplayName("코스 여러개 조회")
+    void getList() throws Exception {
+        //given
+        List<Course> Courses = IntStream.range(1, 30)
+                .mapToObj(i -> Course.builder()
+                        .name("코스 " + i)
+                        .build())
+                .toList();
+
+        courseRepository.saveAll(Courses);
+
+        //when
+        List<CourseResponse> getLists = courseService.getList();
+
+        //then
+        assertEquals(courseRepository.count(), getLists.size());
+        assertEquals("코스 1", getLists.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("코스 수정")
+    void updateCourse() throws Exception {
+        //given
+        Course course = Course.builder()
+                .name("코스 1")
+                .build();
+        courseRepository.save(course);
+
+        UpdateCourse updateCourse = UpdateCourse.builder()
+                .name("코스 2")
+                .build();
+
+        User user = userCreate();
+        userRepository.save(user);
+        LoginResponse loginResponse = loginCreate(user);
+
+        //when
+        courseService.updateCourse(loginResponse, course.getId(), updateCourse);
+
+        //then
+        Course updatedCourse = courseRepository.findById(course.getId())
+                .orElseThrow(() -> new NoSuchElementException("해당 코스가 없습니다. id=" + 1L));
+
+        assertEquals(1, courseRepository.count());
+        assertEquals("코스 2", courseRepository.findAll().get(0).getName());
+    }
+
+    @Test
+    @DisplayName("코스 삭제")
+    void deleteCourse() throws Exception {
+        //given
+        Course course = Course.builder()
+                .name("코스 1")
+                .build();
+        courseRepository.save(course);
+
+        //when
+        courseService.deleteCourse(course.getId());
+
+        //then
+        assertEquals(0, courseRepository.count());
+    }
+}


### PR DESCRIPTION
## 📝작업 내용
코스의 기본적인 기능을 구현해놨고,  api 명세서의 틀을 잡았습니다. 

## 💬리뷰 참고사항
♣테스트 케이스에 뭐가 더 추가 됐으면 좋을지에 대해 얘기해주시면 감사하겠습니다.!

mockMvc 안에 document 메서드로 api 문서 자동 생성이 가능합니다.

<img width="529" alt="image" src="https://github.com/b3f2/back-end/assets/103359817/93aed769-af87-4788-bce7-c9a384d56761">

API 명세서 위치는 /src/docs/asciidoc/index.adoc 입니다.  DocsTest를 검증하면 /build 폴더 안에 자동생성 됩니다. 채울 곳이 있다면 양식에 맞춰 수정하시면 됩니다.
예시)
<img width="183" alt="image" src="https://github.com/b3f2/back-end/assets/103359817/aa89bba3-8f88-4bd9-9203-ad8c74b92e58">
<img width="430" alt="image" src="https://github.com/b3f2/back-end/assets/103359817/bfc20320-201f-494d-aa32-06ec6cb89e65">

## 테스트 주의 사항
*