### PR TITLE
Feat/course api

### DIFF
--- a/src/main/java/com/backend/api/controller/ApiControllerAdvice.java
+++ b/src/main/java/com/backend/api/controller/ApiControllerAdvice.java
@@ -21,11 +21,11 @@ public class ApiControllerAdvice {
         );
     }
 
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(CourseNotFoundException.class)
     public ApiResponse<Object> handleInvalidCourseException(CourseNotFoundException e) {
         return ApiResponse.of(
-                HttpStatus.NOT_FOUND,
+                HttpStatus.BAD_REQUEST,
                 e.getMessage(),
                 null
         );

--- a/src/main/java/com/backend/api/controller/ApiControllerAdvice.java
+++ b/src/main/java/com/backend/api/controller/ApiControllerAdvice.java
@@ -21,9 +21,19 @@ public class ApiControllerAdvice {
         );
     }
 
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(InvalidUserException.class)
+    public ApiResponse<Object> handleInvalidUserException(InvalidUserException e) {
+        return ApiResponse.of(
+                HttpStatus.UNAUTHORIZED,
+                e.getMessage(),
+                null
+        );
+    }
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(CourseNotFoundException.class)
-    public ApiResponse<Object> handleInvalidCourseException(CourseNotFoundException e) {
+    public ApiResponse<Object> handleCourseNotFoundException(CourseNotFoundException e) {
         return ApiResponse.of(
                 HttpStatus.BAD_REQUEST,
                 e.getMessage(),
@@ -31,11 +41,11 @@ public class ApiControllerAdvice {
         );
     }
 
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(InvalidUserException.class)
-    public ApiResponse<Object> handleInvalidUserException(InvalidUserException e) {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(CourseReviewNotFoundException.class)
+    public ApiResponse<Object> handleCourseReviewNotFoundException(CourseReviewNotFoundException e) {
         return ApiResponse.of(
-                HttpStatus.UNAUTHORIZED,
+                HttpStatus.BAD_REQUEST,
                 e.getMessage(),
                 null
         );

--- a/src/main/java/com/backend/api/controller/course/CourseController.java
+++ b/src/main/java/com/backend/api/controller/course/CourseController.java
@@ -56,7 +56,7 @@ public class CourseController {
     }
 
     //코스 목록 조회(사용자 id 값으로)
-    @GetMapping("/users/{userId}/courses")
+    @GetMapping("/user/{userId}/courses")
     public ApiResponse<List<CourseResponse>> getUserCourses(@PathVariable Long userId) {
         return ApiResponse.ok(courseService.getCoursesByUserId(userId));
     }

--- a/src/main/java/com/backend/api/controller/course/CourseReviewController.java
+++ b/src/main/java/com/backend/api/controller/course/CourseReviewController.java
@@ -56,7 +56,7 @@ public class CourseReviewController {
     }
 
     //코스 리뷰 가져오기(사용자 id로)
-    @GetMapping("/users/{userId}/course-review")
+    @GetMapping("/user/{userId}/course-review")
     public ApiResponse<List<CourseReviewResponse>> getCourseReviewByUserId(@PathVariable Long userId) {
         return ApiResponse.ok(courseReviewService.getCourseReviewByUserId(userId));
     }

--- a/src/main/java/com/backend/api/request/course/CreateCourseReview.java
+++ b/src/main/java/com/backend/api/request/course/CreateCourseReview.java
@@ -3,6 +3,7 @@ package com.backend.api.request.course;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -15,8 +16,10 @@ public class CreateCourseReview {
 
     @Min(value = 0, message = "0~5 사이의 숫자를 입력해 주세요")
     @Max(value = 5, message = "0~5 사이의 숫자를 입력해 주세요")
+    @NotNull(message = "평점을 입력해 주세요")
     private int rating;
 
+    @NotNull(message = "코스 Id를 입력해 주세요")
     private Long courseId;
 
     @Builder

--- a/src/main/java/com/backend/api/request/course/UpdateCourseReview.java
+++ b/src/main/java/com/backend/api/request/course/UpdateCourseReview.java
@@ -1,6 +1,7 @@
 package com.backend.api.request.course;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -11,8 +12,10 @@ public class UpdateCourseReview {
     @NotBlank(message = "리뷰 내용을 입력해 주세요")
     private String content;
 
+    @NotNull(message = "리뷰 점수를 입력해 주세요")
     private int rating;
 
+    @NotNull(message = "코스 Id를 입력해 주세요")
     private Long courseId;
 
     @Builder

--- a/src/test/java/com/backend/api/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/backend/api/controller/auth/AuthControllerTest.java
@@ -49,7 +49,7 @@ class AuthControllerTest {
         userRepository.save(userCreate());
 
         LoginRequest request = LoginRequest.builder()
-                .email("user@gmail.com")
+                .email("userTest@gmail.com")
                 .password("1111")
                 .build();
 
@@ -73,7 +73,7 @@ class AuthControllerTest {
         // given
         userRepository.save(userCreate());
         LoginRequest request = LoginRequest.builder()
-                .email("user@gmail.com")
+                .email("userTest@gmail.com")
                 .password("1111")
                 .build();
 
@@ -96,7 +96,7 @@ class AuthControllerTest {
         // given
         userRepository.save(userCreate());
         LoginRequest request = LoginRequest.builder()
-                .email("user@gmail.com")
+                .email("userTest@gmail.com")
                 .password("1111")
                 .build();
 
@@ -114,7 +114,7 @@ class AuthControllerTest {
 
     private User userCreate() {
         return User.builder()
-                .email("user@gmail.com")
+                .email("userTest@gmail.com")
                 .password(passwordEncoder.encode("1111"))
                 .nickName("user")
                 .address(Address.builder()

--- a/src/test/java/com/backend/api/controller/course/CourseControllerTest.java
+++ b/src/test/java/com/backend/api/controller/course/CourseControllerTest.java
@@ -123,8 +123,8 @@ public class CourseControllerTest extends ControllerTestSupport {
         //expected
         mockMvc.perform(get("/api/courses/{id}", 1))
                 .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("404"));
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"));
 
     }
 
@@ -246,8 +246,8 @@ public class CourseControllerTest extends ControllerTestSupport {
                         .content(json)
                 )
                 .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.message").value("해당 코스가 없습니다."))
                 .andExpect(jsonPath("$.data").isEmpty());
     }
@@ -330,8 +330,8 @@ public class CourseControllerTest extends ControllerTestSupport {
         mockMvc.perform(delete("/api/courses/{id}", 1L)
                 )
                 .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.message").value("해당 코스가 없습니다."));
     }
 }

--- a/src/test/java/com/backend/api/controller/course/CourseControllerTest.java
+++ b/src/test/java/com/backend/api/controller/course/CourseControllerTest.java
@@ -169,7 +169,7 @@ public class CourseControllerTest extends ControllerTestSupport {
         courseRepository.saveAll(courses);
 
         //expected
-        mockMvc.perform(get("/api/users/{userId}/courses", user.getId()))
+        mockMvc.perform(get("/api/user/{userId}/courses", user.getId()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].name").value("코스 1"))
@@ -180,7 +180,7 @@ public class CourseControllerTest extends ControllerTestSupport {
     @DisplayName("없는 사용자의 코스 목록 조회")
     void getEmptyListByUserId() throws Exception {
         //expected
-        mockMvc.perform(get("/api/users/{userId}/courses", 1L))
+        mockMvc.perform(get("/api/user/{userId}/courses", 1L))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isEmpty());

--- a/src/test/java/com/backend/api/controller/course/CourseReviewControllerTest.java
+++ b/src/test/java/com/backend/api/controller/course/CourseReviewControllerTest.java
@@ -206,7 +206,7 @@ class CourseReviewControllerTest extends ControllerTestSupport {
 
 
         //expected
-        mockMvc.perform(get("/api/users/{userId}/course-review", user.getId()))
+        mockMvc.perform(get("/api/user/{userId}/course-review", user.getId()))
                 .andDo(print())
                 .andExpect(status().isOk());
         List<CourseReview> courseReviewList = courseReviewRepository.findAll();
@@ -221,15 +221,26 @@ class CourseReviewControllerTest extends ControllerTestSupport {
     }
 
     @Test
-    @DisplayName("없는 코스 리뷰 조회")
-    void getEmptyCourseReview() throws Exception {
+    @DisplayName("없는 모든 코스 리뷰 조회")
+    void getEmptyCourseReviewList() throws Exception {
         //expected
         mockMvc.perform(get("/api/course-review"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isEmpty());
     }
-
+    @Test
+    @DisplayName("없는 코스 리뷰 단건 조회")
+    @WithMockCustomUser
+    void getEmptyCourseReview() throws Exception {
+        //expected
+        mockMvc.perform(get("/api/course-review/{id}", 1L))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("해당 코스 리뷰가 없습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
     @Test
     @DisplayName("코스 리뷰 수정")
     @WithMockCustomUser

--- a/src/test/java/com/backend/api/docs/course/CourseControllerDocTest.java
+++ b/src/test/java/com/backend/api/docs/course/CourseControllerDocTest.java
@@ -162,7 +162,7 @@ class CourseControllerDocTest extends RestDocsSupport {
                 ));
 
         //expected
-        mockMvc.perform(get("/api/users/{userId}/courses", 1L)
+        mockMvc.perform(get("/api/user/{userId}/courses", 1L)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8"))
                 .andDo(print())

--- a/src/test/java/com/backend/api/docs/course/CourseReviewControllerDocTest.java
+++ b/src/test/java/com/backend/api/docs/course/CourseReviewControllerDocTest.java
@@ -189,7 +189,7 @@ public class CourseReviewControllerDocTest extends RestDocsSupport {
                                 .build()));
 
         //expected
-        mockMvc.perform(get("/api/users/{userId}/course-review", 1L)
+        mockMvc.perform(get("/api/user/{userId}/course-review", 1L)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8"))
                 .andDo(print())


### PR DESCRIPTION
## 📝작업 내용
1. 해당 코스를 못 찾을 때 404오류를 리턴했지만 이는 URI를 조회하지 못했다는 의미가 강하여 400으로 바꾸었습니다.

2. 회원 정보 수정에서 /api/user 경로를 사용하여 /users -> /user로 경로 변경하였습니다.

## 💬리뷰 참고사항
PR 받아지는 대로 CourseLocal 관련도 업로드할 예정입니다.